### PR TITLE
Add placeholder routes for unfinished pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import AuthPage from "./pages/auth/AuthPage";
 import DashboardPage from "./pages/dashboard/DashboardPage";
 import ConversationsPage from "./pages/conversations/ConversationsPage";
 import NotFound from "./pages/NotFound";
+import PlaceholderPage from "./pages/PlaceholderPage";
 
 const queryClient = new QueryClient();
 
@@ -41,6 +42,55 @@ const App = () => (
             <ProtectedRoute>
               <DashboardLayout>
                 <ConversationsPage />
+              </DashboardLayout>
+            </ProtectedRoute>
+          } />
+          <Route path="/customers" element={
+            <ProtectedRoute>
+              <DashboardLayout>
+                <PlaceholderPage title="Clientes" />
+              </DashboardLayout>
+            </ProtectedRoute>
+          } />
+          <Route path="/sales" element={
+            <ProtectedRoute>
+              <DashboardLayout>
+                <PlaceholderPage title="Funil de Vendas" />
+              </DashboardLayout>
+            </ProtectedRoute>
+          } />
+          <Route path="/reports" element={
+            <ProtectedRoute>
+              <DashboardLayout>
+                <PlaceholderPage title="Relatórios" />
+              </DashboardLayout>
+            </ProtectedRoute>
+          } />
+          <Route path="/auto-responses" element={
+            <ProtectedRoute>
+              <DashboardLayout>
+                <PlaceholderPage title="Respostas Automáticas" />
+              </DashboardLayout>
+            </ProtectedRoute>
+          } />
+          <Route path="/bot-settings" element={
+            <ProtectedRoute>
+              <DashboardLayout>
+                <PlaceholderPage title="Configurações do Bot" />
+              </DashboardLayout>
+            </ProtectedRoute>
+          } />
+          <Route path="/operators" element={
+            <ProtectedRoute>
+              <DashboardLayout>
+                <PlaceholderPage title="Operadores" />
+              </DashboardLayout>
+            </ProtectedRoute>
+          } />
+          <Route path="/settings" element={
+            <ProtectedRoute>
+              <DashboardLayout>
+                <PlaceholderPage title="Configurações" />
               </DashboardLayout>
             </ProtectedRoute>
           } />

--- a/src/pages/PlaceholderPage.tsx
+++ b/src/pages/PlaceholderPage.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+interface PlaceholderPageProps {
+  title: string;
+}
+
+const PlaceholderPage = ({ title }: PlaceholderPageProps) => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <h1 className="text-2xl font-bold">{title} - Em desenvolvimento</h1>
+    </div>
+  );
+};
+
+export default PlaceholderPage;


### PR DESCRIPTION
## Summary
- add placeholder page component
- wire up placeholder routes for customers, sales, reports, automation, bot settings, operators, and settings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: pre-existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_6891ff59c6708321a9528eb0f81c77a2