### PR TITLE
fix: update realtime subscription for whatsapp session

### DIFF
--- a/src/pages/whatsapp/WhatsAppConnectionPage.tsx
+++ b/src/pages/whatsapp/WhatsAppConnectionPage.tsx
@@ -29,7 +29,9 @@ export default function WhatsAppConnectionPage() {
           table: 'whatsapp_sessions'
         },
         (payload) => {
-          if (payload.eventType === 'UPDATE' && payload.new) {
+          if (payload.eventType === 'DELETE') {
+            setSession(null);
+          } else if (payload.new) {
             setSession(payload.new as WhatsAppSession);
           }
         }


### PR DESCRIPTION
## Summary
- update WhatsApp session subscription to handle new and deleted sessions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any, fast refresh warnings)


------
https://chatgpt.com/codex/tasks/task_e_689b2faa7190832181d95e68c49a101e