### PR TITLE
Replace Baileys with whatsapp-web.js for WhatsApp connection

### DIFF
--- a/supabase/functions/wa-ws/index.ts
+++ b/supabase/functions/wa-ws/index.ts
@@ -1,12 +1,8 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-// Import Baileys - usando versão específica que funciona no Deno
-import makeWASocket, { 
-  DisconnectReason, 
-  useMultiFileAuthState,
-  fetchLatestBaileysVersion 
-} from "https://esm.sh/@whiskeysockets/baileys@6.7.8";
+// Import whatsapp-web.js via ESM
+import { Client as WWebClient, LocalAuth } from "https://esm.sh/whatsapp-web.js@1.23.0";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -68,169 +64,73 @@ serve(async (req) => {
     try {
       // Check if connection already exists
       if (activeConnections.has(user.id)) {
-        const existingWASocket = activeConnections.get(user.id);
-        if (existingWASocket?.user?.id) {
-          socket.send(JSON.stringify({
+        socket.send(
+          JSON.stringify({
             type: "status",
             status: "connected",
-            message: "Already connected to WhatsApp"
-          }));
-          return;
-        } else {
-          // Clean up stale connection
-          activeConnections.delete(user.id);
-        }
+            message: "Already connected to WhatsApp",
+          }),
+        );
+        return;
       }
 
-      // Create auth state adapter for database storage
-      const authStateAdapter = {
-        readData: async (file: string) => {
-          try {
-            const { data } = await supabase
-              .from("whatsapp_auth")
-              .select("data")
-              .eq("user_id", user.id)
-              .single();
-            
-            return data?.data?.[file] || null;
-          } catch (error) {
-            console.log(`No auth data found for ${file}:`, error.message);
-            return null;
-          }
-        },
-        writeData: async (file: string, data: any) => {
-          try {
-            const { data: existingData } = await supabase
-              .from("whatsapp_auth")
-              .select("data")
-              .eq("user_id", user.id)
-              .single();
-
-            const authData = existingData?.data || {};
-            authData[file] = data;
-
-            await supabase
-              .from("whatsapp_auth")
-              .upsert({ 
-                user_id: user.id, 
-                data: authData 
-              });
-          } catch (error) {
-            console.error(`Error writing auth data for ${file}:`, error);
-          }
-        },
-        removeData: async (file: string) => {
-          try {
-            const { data: existingData } = await supabase
-              .from("whatsapp_auth")
-              .select("data")
-              .eq("user_id", user.id)
-              .single();
-
-            if (existingData?.data) {
-              delete existingData.data[file];
-              await supabase
-                .from("whatsapp_auth")
-                .update({ data: existingData.data })
-                .eq("user_id", user.id);
-            }
-          } catch (error) {
-            console.error(`Error removing auth data for ${file}:`, error);
-          }
-        }
-      };
-
-      // Start WhatsApp connection
-      const { version, isLatest } = await fetchLatestBaileysVersion();
-      console.log(`Using WA v${version.join('.')}, isLatest: ${isLatest}`);
-
-      const waSocket = makeWASocket({
-        version,
-        printQRInTerminal: false,
-        auth: {
-          creds: await authStateAdapter.readData("creds.json") || undefined,
-          keys: await authStateAdapter.readData("app-state-sync-key") || {}
-        },
-        // Configurações de conexão
-        browser: ["WA Team Desk", "Chrome", "1.0.0"],
-        markOnlineOnConnect: true
+      // Start WhatsApp connection using whatsapp-web.js
+      const waClient = new WWebClient({
+        authStrategy: new LocalAuth({ clientId: user.id }),
+        puppeteer: { headless: true },
       });
 
       // Store connection
-      activeConnections.set(user.id, waSocket);
+      activeConnections.set(user.id, waClient);
 
-      waSocket.ev.on("connection.update", async (update) => {
-        const { connection, lastDisconnect, qr } = update;
-        
-        console.log(`Connection update for user ${user.id}:`, { connection, qr: !!qr });
+      waClient.on("qr", async (qr: string) => {
+        socket.send(JSON.stringify({ type: "qr", qr }));
 
-        if (qr) {
-          // Send QR code to client
-          socket.send(JSON.stringify({
-            type: "qr",
-            qr: qr
-          }));
-          
-          await supabase
-            .from("whatsapp_status")
-            .upsert({ user_id: user.id, status: "qr_ready" });
-        }
+        await supabase
+          .from("whatsapp_status")
+          .upsert({ user_id: user.id, status: "qr_ready" });
+      });
 
-        if (connection === "close") {
-          const shouldReconnect = (lastDisconnect?.error as any)?.output?.statusCode !== DisconnectReason.loggedOut;
-          
-          console.log(`Connection closed for user ${user.id}, shouldReconnect:`, shouldReconnect);
-          
-          if (shouldReconnect) {
-            await supabase
-              .from("whatsapp_status")
-              .upsert({ user_id: user.id, status: "reconnecting" });
-              
-            socket.send(JSON.stringify({
-              type: "status",
-              status: "reconnecting",
-              message: "Connection lost, attempting to reconnect..."
-            }));
-          } else {
-            await supabase
-              .from("whatsapp_status")
-              .upsert({ user_id: user.id, status: "disconnected" });
-              
-            socket.send(JSON.stringify({
-              type: "status",
-              status: "disconnected",
-              message: "Logged out from WhatsApp"
-            }));
-          }
-          
-          activeConnections.delete(user.id);
-        } else if (connection === "open") {
-          console.log(`WhatsApp connected for user ${user.id}`);
-          
-          await supabase
-            .from("whatsapp_status")
-            .upsert({ user_id: user.id, status: "connected" });
-            
-          socket.send(JSON.stringify({
+      waClient.on("ready", async () => {
+        console.log(`WhatsApp connected for user ${user.id}`);
+
+        await supabase
+          .from("whatsapp_status")
+          .upsert({ user_id: user.id, status: "connected" });
+
+        socket.send(
+          JSON.stringify({
             type: "status",
             status: "connected",
-            message: "Successfully connected to WhatsApp!"
-          }));
-        }
+            message: "Successfully connected to WhatsApp!",
+          }),
+        );
       });
 
-      waSocket.ev.on("creds.update", async (creds) => {
-        await authStateAdapter.writeData("creds.json", creds);
-      });
+      waClient.on("disconnected", async (reason: unknown) => {
+        console.log(`Connection closed for user ${user.id}:`, reason);
 
-      waSocket.ev.on("auth-state.update", async ({ keys }) => {
-        await authStateAdapter.writeData("app-state-sync-key", keys);
+        await supabase
+          .from("whatsapp_status")
+          .upsert({ user_id: user.id, status: "disconnected" });
+
+        socket.send(
+          JSON.stringify({
+            type: "status",
+            status: "disconnected",
+            message: "Logged out from WhatsApp",
+          }),
+        );
+
+        activeConnections.delete(user.id);
       });
 
       // Initial status
       await supabase
         .from("whatsapp_status")
         .upsert({ user_id: user.id, status: "connecting" });
+
+      await waClient.initialize();
 
     } catch (error) {
       console.error(`Error setting up WhatsApp for user ${user.id}:`, error);
@@ -252,8 +152,8 @@ serve(async (req) => {
     // Clean up connection after delay to allow reconnection
     setTimeout(() => {
       if (activeConnections.has(user.id)) {
-        const waSocket = activeConnections.get(user.id);
-        waSocket?.end();
+        const client = activeConnections.get(user.id);
+        client?.destroy();
         activeConnections.delete(user.id);
       }
     }, 30000); // 30 seconds delay

--- a/supabase/migrations/20250813002852-.sql
+++ b/supabase/migrations/20250813002852-.sql
@@ -1,5 +1,5 @@
 -- WhatsApp auth storage and status tables
--- 1) Credentials as a JSON blob (Baileys creds + keys), per user
+-- 1) Credentials as a JSON blob (WhatsApp session data), per user
 CREATE TABLE IF NOT EXISTS public.whatsapp_auth (
   user_id uuid PRIMARY KEY,
   data jsonb NOT NULL DEFAULT '{}'::jsonb,

--- a/supabase/migrations/20250813002915-.sql
+++ b/supabase/migrations/20250813002915-.sql
@@ -1,5 +1,5 @@
 -- WhatsApp auth storage and status tables
--- 1) Credentials as a JSON blob (Baileys creds + keys), per user
+-- 1) Credentials as a JSON blob (WhatsApp session data), per user
 CREATE TABLE IF NOT EXISTS public.whatsapp_auth (
   user_id uuid PRIMARY KEY,
   data jsonb NOT NULL DEFAULT '{}'::jsonb,


### PR DESCRIPTION
## Summary
- swap Baileys for whatsapp-web.js in the WebSocket handler and update connection lifecycle
- clarify migration comments to reference generic WhatsApp session data

## Testing
- `npm run lint` *(fails: Unexpected any and require import errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689bdffca144832fa2a69e2b03184349