### PR TITLE
fix: use backend websocket url for whatsapp connection

### DIFF
--- a/src/pages/whatsapp/WhatsAppConnectionPage.tsx
+++ b/src/pages/whatsapp/WhatsAppConnectionPage.tsx
@@ -81,13 +81,13 @@ export default function WhatsAppConnectionPage() {
       }
 
       // Start WA connection
-      const { data, error } = await supabase.functions.invoke('wa-start', {
+      const { data: startData, error } = await supabase.functions.invoke('wa-start', {
         headers: {
           Authorization: `Bearer ${session.access_token}`,
         },
       });
 
-      if (error) {
+      if (error || !startData?.wsUrl) {
         console.error('Error starting connection:', error);
         toast({
           title: "Erro",
@@ -101,14 +101,14 @@ export default function WhatsAppConnectionPage() {
         title: "Sucesso",
         description: "Iniciando conexão WhatsApp..."
       });
-      
+
       // Open WebSocket connection
-      const wsUrl = `wss://bobpwdzonobaeglewuer.functions.supabase.co/functions/v1/wa-ws?token=${session.access_token}`;
-      
+      const wsUrl = startData.wsUrl as string;
+
       if (wsRef.current) {
         wsRef.current.close();
       }
-      
+
       wsRef.current = new WebSocket(wsUrl);
       
       wsRef.current.onopen = () => {


### PR DESCRIPTION
## Summary
- use WebSocket URL returned by `wa-start` function

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: see errors above)


------
https://chatgpt.com/codex/tasks/task_e_689c7cfeb240832f9cc4a24ca62b0466