### PR TITLE
Fix QR code rendering after connection

### DIFF
--- a/src/pages/whatsapp/WhatsAppConnectionPage.tsx
+++ b/src/pages/whatsapp/WhatsAppConnectionPage.tsx
@@ -17,6 +17,19 @@ export default function WhatsAppConnectionPage() {
   const qrCanvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
+    if (qrCode && qrCanvasRef.current) {
+      QRCodeLib.toCanvas(qrCanvasRef.current, qrCode, {
+        width: 256,
+        margin: 2,
+        color: {
+          dark: '#000000',
+          light: '#FFFFFF'
+        }
+      });
+    }
+  }, [qrCode]);
+
+  useEffect(() => {
     fetchStatus();
     return () => {
       if (wsRef.current) {
@@ -125,17 +138,6 @@ export default function WhatsAppConnectionPage() {
             setQrCode(message.qr);
             setStatus('qr_ready');
             
-            // Generate QR code image
-            if (qrCanvasRef.current) {
-              await QRCodeLib.toCanvas(qrCanvasRef.current, message.qr, {
-                width: 256,
-                margin: 2,
-                color: {
-                  dark: '#000000',
-                  light: '#FFFFFF'
-                }
-              });
-            }
             
             toast({
               title: "QR Code gerado",


### PR DESCRIPTION
## Summary
- Render WhatsApp QR codes after state updates using a dedicated effect
- Simplify WebSocket QR handler

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c84281410832fbc176e263f379520