### PR TITLE
fix: send WhatsApp QR images via Baileys

### DIFF
--- a/supabase/functions/wa-ws/index.ts
+++ b/supabase/functions/wa-ws/index.ts
@@ -1,167 +1,261 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-// Import whatsapp-web.js via ESM
-import { Client as WWebClient, LocalAuth } from "https://esm.sh/whatsapp-web.js@1.23.0";
+// Import Baileys and helpers via ESM shim for Deno
+import makeWASocket, {
+  DisconnectReason,
+  fetchLatestBaileysVersion,
+  useMultiFileAuthState,
+  WASocket,
+} from "https://esm.sh/@whiskeysockets/baileys@6.7.7";
+
+// Lightweight QR encoder that outputs base64 data URLs
+import QRCode from "https://esm.sh/qrcode@1.5.4";
+
+// Logger – avoid printing sensitive data such as the raw QR string
+import Pino from "https://esm.sh/pino@8.17.0";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
 };
 
-// Map to store active connections per user
-const activeConnections = new Map();
+// Active connections per user id
+const activeConnections = new Map<string, WASocket>();
+
+// Minimal type for Boom style errors so we don't rely on `any`
+interface BoomError {
+  output?: { statusCode?: number };
+}
 
 serve(async (req) => {
-  const { headers } = req;
-  const upgradeHeader = headers.get("upgrade") || "";
-
+  const upgradeHeader = req.headers.get("upgrade") || "";
   if (upgradeHeader.toLowerCase() !== "websocket") {
-    return new Response("Expected WebSocket connection", { 
+    return new Response("Expected WebSocket connection", {
       status: 400,
-      headers: corsHeaders 
+      headers: corsHeaders,
     });
   }
 
-  // Get token from query string
+  // Token is passed via query string (?token=)
   const url = new URL(req.url);
   const token = url.searchParams.get("token");
-
   if (!token) {
-    return new Response("Token required", { 
-      status: 401,
-      headers: corsHeaders 
-    });
+    return new Response("Token required", { status: 401, headers: corsHeaders });
   }
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
   const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-
   if (!supabaseUrl || !serviceKey) {
-    return new Response("Server configuration error", { 
+    return new Response("Server configuration error", {
       status: 500,
-      headers: corsHeaders 
+      headers: corsHeaders,
     });
   }
 
   const supabase = createClient(supabaseUrl, serviceKey);
 
-  // Verify JWT token
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+  // Validate the JWT token to obtain user info
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser(token);
 
   if (authError || !user) {
-    return new Response("Invalid token", { 
-      status: 401,
-      headers: corsHeaders 
-    });
+    return new Response("Invalid token", { status: 401, headers: corsHeaders });
   }
 
   const { socket, response } = Deno.upgradeWebSocket(req);
 
   socket.onopen = async () => {
-    console.log(`WebSocket opened for user ${user.id}`);
-    
-    try {
-      // Check if connection already exists
-      if (activeConnections.has(user.id)) {
-        socket.send(
-          JSON.stringify({
-            type: "status",
-            status: "connected",
-            message: "Already connected to WhatsApp",
-          }),
-        );
-        return;
+    const userId = user.id;
+    const logger = Pino({ level: "info" });
+    logger.info({ user: userId }, "WebSocket opened");
+
+    // If we already have a running connection, just notify the client
+    if (activeConnections.has(userId)) {
+      socket.send(
+        JSON.stringify({
+          type: "status",
+          status: "connected",
+          message: "Already connected to WhatsApp",
+        }),
+      );
+      return;
+    }
+
+    // Helper to actually start the Baileys socket
+    const startSock = async () => {
+      // Each user has its own auth directory to keep sessions isolated
+      const { state, saveCreds } = await useMultiFileAuthState(
+        `./auth/${userId}`,
+      );
+
+      const { version } = await fetchLatestBaileysVersion();
+
+      const sock = makeWASocket({
+        auth: state,
+        logger, // pino instance
+        printQRInTerminal: false,
+        browser: ["WhatsCRM", "Chrome", "1.0"],
+        version,
+      });
+
+      activeConnections.set(userId, sock);
+
+      sock.ev.on("creds.update", saveCreds);
+
+      // Optional pairing code fallback: if environment provides a phone
+      // number and the library supports it, request a pairing code. This
+      // is useful for devices that cannot scan QR codes.
+      const pairingPhone = Deno.env.get("PAIRING_CODE_PHONE");
+      if (pairingPhone && sock.requestPairingCode) {
+        try {
+          const code = await sock.requestPairingCode(pairingPhone);
+          socket.send(JSON.stringify({ type: "pairing", code }));
+          logger.info({ user: userId }, "Pairing code requested");
+        } catch (err) {
+          logger.error({ user: userId, err }, "Failed to request pairing code");
+        }
       }
 
-      // Start WhatsApp connection using whatsapp-web.js
-      const waClient = new WWebClient({
-        authStrategy: new LocalAuth({ clientId: user.id }),
-        puppeteer: { headless: true },
-      });
-
-      // Store connection
-      activeConnections.set(user.id, waClient);
-
-      waClient.on("qr", async (qr: string) => {
-        socket.send(JSON.stringify({ type: "qr", qr }));
-
-        await supabase
-          .from("whatsapp_status")
-          .upsert({ user_id: user.id, status: "qr_ready" });
-      });
-
-      waClient.on("ready", async () => {
-        console.log(`WhatsApp connected for user ${user.id}`);
-
-        await supabase
-          .from("whatsapp_status")
-          .upsert({ user_id: user.id, status: "connected" });
-
-        socket.send(
-          JSON.stringify({
-            type: "status",
-            status: "connected",
-            message: "Successfully connected to WhatsApp!",
-          }),
-        );
-      });
-
-      waClient.on("disconnected", async (reason: unknown) => {
-        console.log(`Connection closed for user ${user.id}:`, reason);
-
-        await supabase
-          .from("whatsapp_status")
-          .upsert({ user_id: user.id, status: "disconnected" });
-
-        socket.send(
-          JSON.stringify({
-            type: "status",
-            status: "disconnected",
-            message: "Logged out from WhatsApp",
-          }),
-        );
-
-        activeConnections.delete(user.id);
-      });
-
-      // Initial status
+      // Status in DB while we connect
       await supabase
         .from("whatsapp_status")
-        .upsert({ user_id: user.id, status: "connecting" });
+        .upsert({ user_id: userId, status: "connecting" });
 
-      await waClient.initialize();
+      // Listen for connection updates (QR, open/close, errors)
+      sock.ev.on("connection.update", async (update) => {
+        const { connection, lastDisconnect, qr, pairingCode } = update;
 
-    } catch (error) {
-      console.error(`Error setting up WhatsApp for user ${user.id}:`, error);
-      
-      socket.send(JSON.stringify({
-        type: "error",
-        message: "Failed to initialize WhatsApp connection"
-      }));
-      
+        if (qr) {
+          // Convert QR string to base64 PNG and send to frontend
+          const qrImage = await QRCode.toDataURL(qr);
+
+          // Send through WebSocket without logging the raw QR
+          socket.send(JSON.stringify({ type: "qr", qr: qrImage }));
+          logger.info({ user: userId }, "QR code generated");
+
+          // Persist QR for HTTP polling fallback
+          await supabase
+            .from("whatsapp_sessions")
+            .upsert({
+              session_id: userId,
+              qr_code: qrImage,
+              is_connected: false,
+              last_ping_at: new Date().toISOString(),
+            });
+
+          await supabase
+            .from("whatsapp_status")
+            .upsert({ user_id: userId, status: "qr_ready" });
+        }
+
+        // Pairing code fallback if the device supports it
+        if (pairingCode) {
+          socket.send(JSON.stringify({ type: "pairing", code: pairingCode }));
+          logger.info({ user: userId }, "Pairing code generated");
+        }
+
+        if (connection === "open") {
+          // Successfully connected
+          await supabase
+            .from("whatsapp_status")
+            .upsert({ user_id: userId, status: "connected" });
+
+          await supabase
+            .from("whatsapp_sessions")
+            .upsert({
+              session_id: userId,
+              qr_code: null,
+              is_connected: true,
+              last_ping_at: new Date().toISOString(),
+            });
+
+          socket.send(
+            JSON.stringify({
+              type: "status",
+              status: "connected",
+              message: "Successfully connected to WhatsApp!",
+            }),
+          );
+
+          logger.info({ user: userId }, "WhatsApp connected");
+        }
+
+        if (connection === "close") {
+          logger.info({ user: userId, err: lastDisconnect?.error }, "Connection closed");
+
+          await supabase
+            .from("whatsapp_status")
+            .upsert({ user_id: userId, status: "disconnected" });
+
+          socket.send(
+            JSON.stringify({
+              type: "status",
+              status: "disconnected",
+              message: "Disconnected from WhatsApp",
+            }),
+          );
+
+          activeConnections.delete(userId);
+
+          const shouldReconnect =
+            ((lastDisconnect?.error as BoomError)?.output?.statusCode ?? 0) !==
+              DisconnectReason.loggedOut;
+
+          if (shouldReconnect) {
+            // Try to reconnect after short delay
+            setTimeout(() => startSock(), 5000);
+          } else {
+            // Logged out – clear stored session
+            await supabase
+              .from("whatsapp_sessions")
+              .upsert({
+                session_id: userId,
+                qr_code: null,
+                is_connected: false,
+                last_ping_at: new Date().toISOString(),
+              });
+          }
+        }
+      });
+    };
+
+    try {
+      await startSock();
+    } catch (err) {
+      logger.error({ user: userId, err }, "Failed to start WhatsApp socket");
+      socket.send(
+        JSON.stringify({
+          type: "error",
+          message: "Failed to initialize WhatsApp connection",
+        }),
+      );
+
       await supabase
         .from("whatsapp_status")
-        .upsert({ user_id: user.id, status: "error" });
+        .upsert({ user_id: userId, status: "error" });
     }
   };
 
   socket.onclose = () => {
     console.log(`WebSocket closed for user ${user.id}`);
-    
-    // Clean up connection after delay to allow reconnection
+
+    // Allow small grace period before destroying in case client reconnects
     setTimeout(() => {
-      if (activeConnections.has(user.id)) {
-        const client = activeConnections.get(user.id);
-        client?.destroy();
-        activeConnections.delete(user.id);
-      }
-    }, 30000); // 30 seconds delay
+      const conn = activeConnections.get(user.id);
+      conn?.end?.();
+      activeConnections.delete(user.id);
+    }, 30000); // 30s
   };
 
-  socket.onerror = (error) => {
-    console.error(`WebSocket error for user ${user.id}:`, error);
+  socket.onerror = (err) => {
+    console.error(`WebSocket error for user ${user.id}:`, err);
   };
 
   return response;
 });
+

--- a/supabase/functions/whatsapp-connect/index.ts
+++ b/supabase/functions/whatsapp-connect/index.ts
@@ -3,7 +3,8 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
 };
 
 serve(async (req) => {
@@ -25,41 +26,46 @@ serve(async (req) => {
 
     const supabase = createClient(supabaseUrl, serviceKey);
 
-    // Generate a placeholder QR code as an SVG data URL
-    const sessionId = crypto.randomUUID();
-    const svg = `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256'>
-  <rect width='100%' height='100%' fill='#111827'/>
-  <rect x='32' y='32' width='192' height='192' fill='none' stroke='#10b981' stroke-width='8' stroke-dasharray='8 8'/>
-  <text x='50%' y='48%' dominant-baseline='middle' text-anchor='middle' fill='#10b981' font-family='monospace' font-size='14'>Escaneie no WhatsApp</text>
-  <text x='50%' y='58%' dominant-baseline='middle' text-anchor='middle' fill='#9ca3af' font-family='monospace' font-size='12'>Sessão ${sessionId.slice(0, 8)}</text>
-</svg>`;
-    const qrDataUrl = `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
-
-    const { data, error } = await supabase
-      .from("whatsapp_sessions")
-      .insert([
-        {
-          session_id: sessionId,
-          is_connected: false,
-          qr_code: qrDataUrl,
-          last_ping_at: new Date().toISOString(),
-        },
-      ])
-      .select()
-      .single();
-
-    if (error) {
-      console.error("Error inserting whatsapp session", error);
-      return new Response(JSON.stringify({ error: error.message }), {
-        status: 400,
+    // Authenticate user
+    const authHeader = req.headers.get("authorization");
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: "Authorization required" }), {
+        status: 401,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
     }
 
-    return new Response(JSON.stringify({ ok: true, session: data }), {
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser(authHeader.replace("Bearer ", ""));
+
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: "Invalid token" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    // Return last generated QR code for this user's session
+    const { data, error } = await supabase
+      .from("whatsapp_sessions")
+      .select("qr_code, is_connected, last_ping_at")
+      .eq("session_id", user.id)
+      .single();
+
+    if (error) {
+      console.error("Error fetching whatsapp session", error);
+      return new Response(JSON.stringify({ error: "Session not found" }), {
+        status: 404,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(
+      JSON.stringify({ ok: true, session: data }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
   } catch (e) {
     console.error("Unexpected error in whatsapp-connect", e);
     return new Response(JSON.stringify({ error: "Unexpected error" }), {


### PR DESCRIPTION
## Summary
- switch WhatsApp WebSocket function to Baileys and generate QR as PNG/base64
- expose latest QR through HTTP endpoint with per-user sessions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 26 problems (17 errors, 9 warnings))*
- `npx eslint supabase/functions/wa-ws/index.ts supabase/functions/whatsapp-connect/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_689c8dbb87f4832f9e0d1183c3f1fbb1